### PR TITLE
pip -> pip3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 ```
 git clone https://github.com/xkonni/snapcastr
 cd snapcastr
-pip install .
+pip3 install .
 ```
 
 ### run/debug


### PR DESCRIPTION
Use `pip3` for installation. This addresses the problem mentioned in #5.