### PR TITLE
Added using friendly names where possible.

### DIFF
--- a/snapcastr/templates/clients.html
+++ b/snapcastr/templates/clients.html
@@ -13,7 +13,7 @@
   </tr>
   {% for form in forms %}
   <tr>
-    <td><div><br/> {{ form.hf.data }} {{ form.hf }} </div></td>
+    <td><div>{{ form.hf.data }} {{ form.hf }} </div></td>
     <td><div class=sc-slider> {{ form.slider }} </div></td>
   </tr>
   {% endfor %}

--- a/snapcastr/templates/groups.html
+++ b/snapcastr/templates/groups.html
@@ -19,9 +19,11 @@
       <div>{{ form.hf }} </div>
     </td>
     <td>
+      <ul>
       {% for client in  form.clients %}
-        {{ client }} <br/>
+        <li>{{ client }}</li>
       {% endfor%}
+      </ul>
     </td>
     <td> {{ form.select }} </td>
   </tr>

--- a/snapcastr/templates/zones.html
+++ b/snapcastr/templates/zones.html
@@ -13,7 +13,7 @@
   </tr>
   {% for form in forms %}
   <tr>
-    <td><div><br/> {{ form.hf.data }} {{ form.hf }} </div></td>
+    <td><div> {{ form.hf.data }} {{ form.hf }} </div></td>
     <td> {{ form.select }} </td>
   </tr>
   {% endfor %}


### PR DESCRIPTION
Fixes #14.

Added using friendly names for clients, groups, streams.
Additionally cleaned a bit templates. `<br/>` in tables are useless, and `group.clients` list actually should look like a list.