### PR TITLE
Basic Docker (and compose) setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Docker
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.7-alpine
+
+COPY . /app/
+
+WORKDIR /app/
+
+RUN pip install -e .
+
+EXPOSE 5011
+
+CMD snapcastrd --bind 0.0.0.0 --port=5011 --host "$SNAPCAST_HOST"

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,0 +1,11 @@
+version: '2'
+
+services:
+  snapcastr:
+    restart: unless-stopped
+    build: .
+    environment:
+      # change me!
+      - SNAPCAST_HOST=192.168.0.100
+    ports:
+      - 5011:5011


### PR DESCRIPTION
Closes #8.

This PR provides a basic Docker setup. The `Dockerfile` can be used to build a Docker image right off the git repository.

Using `docker-compose` you can easily build and setup a container for snapcastr. Just copy the `docker-compose.yml.example` to `docker-compose.yml`, change the environment variable `SNAPCAST_HOST` to the right value (most likely an IP on your LAN), and hit `docker-compose up -d`.